### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toIncludeAllPartialMembers([members])](#toincludeallpartialmembersmembers)
     - [.toIncludeAnyMembers([members])](#toincludeanymembersmembers)
     - [.toIncludeSameMembers([members])](#toincludesamemembersmembers)
-    - [.toPartiallyContain(member)](#topartiallycontain)
+    - [.toPartiallyContain(member)](#topartiallycontainmember)
     - [.toSatisfyAll(predicate)](#tosatisfyallpredicate)
     - [.toSatisfyAny(predicate)](#tosatisfyanypredicate)
   - [Boolean](#boolean)


### PR DESCRIPTION
Fix typo in `toPartiallyContain` internal link

### What

Fix the internal link from the matcher TOC to the `toPartiallyContain` section

### Why

The link is broken.

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
